### PR TITLE
NearFieldCorrection fixes

### DIFF
--- a/mmwave/dsp/compensation.py
+++ b/mmwave/dsp/compensation.py
@@ -169,8 +169,14 @@ def near_field_correction(detected_objects, azimuth_ant_near, num_angle_bins, nu
         None. azimuth_output is changed in-place.
     """
 
-    # LAMBDA_77GHz_MILLIMETER = 3e8 / 77e9
-    LAMBDA_77GHz_MILLIMETER = 3.8e8 / 79e9
+    # From the mmwave sdk 02.01.00.04 : #define MMWDEMO_XWR16XX_EVM_77GHZ_LAMBDA       (3.8961)
+    #    All length units are in mm. The LAMBDA (wavelength) below is based on 77 GHz
+    #    and corresponds to the actual spacing on the EVM, it is not
+    #    tied to the actual start frequency set in profile config, hence does not
+    #    need to be computed on the fly from that configuration.
+    # 3e8 / 77e9 = 0.0038961... in meters -> in millimeter: 3.8961 as above 
+    LAMBDA_77GHz_MILLIMETER = 3e8 / 77e9
+    # LAMBDA_77GHz_MILLIMETER = 3e8 / 79e9
     MMWDEMO_TWO_PI_OVER_LAMBDA = 2.0 * math.pi / LAMBDA_77GHz_MILLIMETER
 
     # Sanity check and check if nearFieldCorrection is necessary.

--- a/mmwave/dsp/compensation.py
+++ b/mmwave/dsp/compensation.py
@@ -174,9 +174,10 @@ def near_field_correction(detected_objects, azimuth_ant_near, num_angle_bins, nu
     #    and corresponds to the actual spacing on the EVM, it is not
     #    tied to the actual start frequency set in profile config, hence does not
     #    need to be computed on the fly from that configuration.
-    # 3e8 / 77e9 = 0.0038961... in meters -> in millimeter: 3.8961 as above 
-    LAMBDA_77GHz_MILLIMETER = 3e8 / 77e9
-    # LAMBDA_77GHz_MILLIMETER = 3e8 / 79e9
+    # lambda = c / f = 3e8 m/s / 77e9 Hz = 0.0038961 m -> in millimeter: 3.8961 mm as above
+    # As all calculations here are meant to be calculated in millimeters, we have to scale lambda accordingly!
+    LAMBDA_77GHz_MILLIMETER = (3e8 / 77e9) * 1000.0
+    # LAMBDA_77GHz_MILLIMETER = (3e8 / 79e9) * 1000.0
     MMWDEMO_TWO_PI_OVER_LAMBDA = 2.0 * math.pi / LAMBDA_77GHz_MILLIMETER
 
     # Sanity check and check if nearFieldCorrection is necessary.


### PR DESCRIPTION
1. The calculation of lambda diverged from the ti sdk source.
2. lambda was represented in meters instead of millimeters as the variable name suggests! Also other variables used with lambda are represented in mm too.